### PR TITLE
Feat: Add jwtExceptionFilter for handling token exception (#89)

### DIFF
--- a/src/main/java/promisor/promisor/domain/member/dto/LoginDto.java
+++ b/src/main/java/promisor/promisor/domain/member/dto/LoginDto.java
@@ -4,17 +4,20 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Data
 public class LoginDto {
 
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 또는 비밀번호를 다시 확인해주세요.")
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
     @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
-            message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
+            message = "이메일 또는 비밀번호를 다시 확인해주세요.")
     private String password;
 
     @Getter

--- a/src/main/java/promisor/promisor/domain/member/dto/SignUpDto.java
+++ b/src/main/java/promisor/promisor/domain/member/dto/SignUpDto.java
@@ -3,6 +3,8 @@ package promisor.promisor.domain.member.dto;
 import lombok.Data;
 import promisor.promisor.domain.member.domain.MemberRole;
 import promisor.promisor.global.error.exception.Enum;
+
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
@@ -11,6 +13,9 @@ public class SignUpDto {
 
     @NotBlank(message = "이름을 입력해주세요.")
     private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 잘못되었습니다.")
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")

--- a/src/main/java/promisor/promisor/global/auth/JwtExceptionFilter.java
+++ b/src/main/java/promisor/promisor/global/auth/JwtExceptionFilter.java
@@ -2,10 +2,14 @@ package promisor.promisor.global.auth;
 
 import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import promisor.promisor.domain.member.exception.EmailEmptyException;
 import promisor.promisor.global.token.JwtExceptionResponse;
+import promisor.promisor.infra.email.exception.EmailNotValid;
 
+import javax.security.sasl.AuthenticationException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -22,6 +26,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             chain.doFilter(request, response);
         } catch (JwtException err) {
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, err);
+        } catch (BadCredentialsException err) {
+            setErrorResponse(HttpStatus.BAD_REQUEST, response, err);
         }
     }
 

--- a/src/main/java/promisor/promisor/global/config/WebSecurityConfig.java
+++ b/src/main/java/promisor/promisor/global/config/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import promisor.promisor.domain.member.service.CustomUserDetailService;
 import promisor.promisor.domain.member.service.MemberLoginFailHandler;
 import promisor.promisor.global.PasswordEncoder;
+import promisor.promisor.global.auth.JwtExceptionFilter;
 import promisor.promisor.global.config.security.CustomAuthenticationFilter;
 import promisor.promisor.global.config.security.JwtAuthenticationFilter;
 import promisor.promisor.global.config.security.JwtProvider;
@@ -53,7 +55,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                                                 .accessDeniedHandler(new WebAccessDeniedHandler())
                                                         .and()
                                                                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
-                                                                        UsernamePasswordAuthenticationFilter.class);
+                                                                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
     }
 
     protected CustomAuthenticationFilter getAuthenticationFilter() throws Exception {

--- a/src/main/java/promisor/promisor/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/promisor/promisor/global/config/security/JwtAuthenticationFilter.java
@@ -2,13 +2,17 @@ package promisor.promisor.global.config.security;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.filter.OncePerRequestFilter;
+import promisor.promisor.domain.member.exception.EmailEmptyException;
 import promisor.promisor.global.error.ErrorCode;
 
 import javax.servlet.*;
@@ -29,16 +33,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtProvider.resolveToken(request);
 
         try {
-            if (jwtProvider.validateJwtToken(token) && token != null) {
+            if (token != null && jwtProvider.validateJwtToken(token)) {
                 Authentication authentication = jwtProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (ExpiredJwtException err) {
-            err.printStackTrace();
-            request.setAttribute("exception", ErrorCode.TOKEN_EXPIRED);
-        } catch (JwtException err) {
-            err.printStackTrace();
-            request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
+            logger.error("token is expired and not valid anymore", err);
+            throw new JwtException("토큰 기한이 만료되었습니다.");
+        } catch (IllegalArgumentException err) {
+            logger.error("an error occurred during getting email from token", err);
+            throw new JwtException("유효하지 않은 토큰정보 입니다.");
+        } catch (SignatureException err) {
+            logger.error("Authentication Failed. Username or Password not valid", err);
+            throw new JwtException("사용자 인증에 실패하였습니다.");
+        } catch (BadCredentialsException err) {
+            logger.error("Incorrect email or password.");
+            throw new BadCredentialsException("이메일 또는 비밀번호를 다시 확인해주세요.");
         }
         chain.doFilter(request, response);
     }

--- a/src/main/java/promisor/promisor/global/config/security/JwtProvider.java
+++ b/src/main/java/promisor/promisor/global/config/security/JwtProvider.java
@@ -80,21 +80,20 @@ public class JwtProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    // JWT decoding 이메일
     public String extractEmail(String token) {
         return (String) Jwts.parser().setSigningKey(secret.getJwtSecretKey()).parseClaimsJws(token).getBody().get("email");
     }
 
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("token");
+        String header = request.getHeader("Authorization");
+        if (header == null) {
+            return null;
+        }
+        return header.replace("Bearer ", "");
     }
 
     public boolean validateJwtToken(String authToken) {
-        try {
-            Jwts.parser().setSigningKey(secret.getJwtSecretKey()).parseClaimsJws(authToken);
-            return true;
-        } catch (Exception err) {
-            return false;
-        }
+        Jwts.parser().setSigningKey(secret.getJwtSecretKey()).parseClaimsJws(authToken);
+        return true;
     }
 }


### PR DESCRIPTION
## 목적
- 토큰 만료
- 잘못된 유저 정보 입력
- 유효하지 않은 토큰
위 예외들을 처리하기 위한 별도의 JwtExceptionFilter를 구현하고 추가해 준다.

## 작업 상세내용
- [ ] JwtExceptionFilter 구현
- [ ] JwtProvider 수정