### PR TITLE
Feat: GetTeamCalendarStatus (#245)

### DIFF
--- a/src/main/java/promisor/promisor/domain/bandate/api/BanDateController.java
+++ b/src/main/java/promisor/promisor/domain/bandate/api/BanDateController.java
@@ -37,7 +37,7 @@ public class BanDateController {
     }
 
     @Operation(summary = "get team calendar detail", description = "팀 캘린더 날짜 별 세부 조회")
-    @GetMapping("/team/{id}/{date}")
+    @GetMapping("/team/{id}/detail/{date}")
     public ResponseEntity<List<GetTeamCalendarResponse>> getTeamCalendar(@JwtAuth String email,
                                                                          @PathVariable("id") Long teamId,
                                                                          @PathVariable("date") String date) {
@@ -66,6 +66,15 @@ public class BanDateController {
     public ResponseEntity<GetPersonalReasonResponse> getPersonalReason(@JwtAuth String email,
                                                                              @PathVariable("date") String date) {
         GetPersonalReasonResponse response = banDateService.getPersonalReason(email, date);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "get team calendar status", description = "팀 캘린더의 전체 상태 조회")
+    @GetMapping("/team/{id}/{yearMonth}")
+    public ResponseEntity<List<GetTeamCalendarStatusResponse>> getTeamCalendarStatus(@JwtAuth String email,
+                                                                               @PathVariable("id") Long id,
+                                                                               @PathVariable("yearMonth") String yearMonth) {
+        List<GetTeamCalendarStatusResponse> response = banDateService.getTeamCalendarStatus(email, id, yearMonth);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/promisor/promisor/domain/bandate/dao/TeamBanDateRepository.java
+++ b/src/main/java/promisor/promisor/domain/bandate/dao/TeamBanDateRepository.java
@@ -26,4 +26,8 @@ public interface TeamBanDateRepository extends JpaRepository<TeamBanDate, Long> 
     @Transactional(readOnly = true)
     @Query("select tbd from TeamBanDate tbd where tbd.team.id=:id and tbd.date=:date")
     Slice<TeamBanDate> findAllByTeamIdAndDate(Long id, LocalDate date, Pageable pageable);
+
+    @Transactional(readOnly = true)
+    @Query("select tbd from TeamBanDate tbd where tbd.team.id=:id and tbd.date=:date")
+    List<TeamBanDate> findAllByTeamIdAndDates(Long id, LocalDate date);
 }

--- a/src/main/java/promisor/promisor/domain/bandate/dto/GetTeamCalendarStatusResponse.java
+++ b/src/main/java/promisor/promisor/domain/bandate/dto/GetTeamCalendarStatusResponse.java
@@ -1,0 +1,17 @@
+package promisor.promisor.domain.bandate.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class GetTeamCalendarStatusResponse {
+
+    private final LocalDate date;
+    private final String dateStatus;
+
+    public GetTeamCalendarStatusResponse(LocalDate date, String dateStatus) {
+        this.date = date;
+        this.dateStatus = dateStatus;
+    }
+}

--- a/src/main/java/promisor/promisor/domain/bandate/service/BanDateService.java
+++ b/src/main/java/promisor/promisor/domain/bandate/service/BanDateService.java
@@ -20,6 +20,7 @@ import promisor.promisor.domain.member.exception.MemberNotFoundException;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -124,5 +125,44 @@ public class BanDateService {
         PersonalBanDate pbd = personalBanDateRepository.getPersonalBanDateByMemberAndDate(member, date);
         List<String> reasons = pbdrList.stream().map(p->p.getReason()).collect(Collectors.toList());
         return new GetPersonalReasonResponse(pbd.getDateStatus(), reasons);
+    }
+
+    public List<GetTeamCalendarStatusResponse> getTeamCalendarStatus(String email, Long teamId, String yearMonth) {
+        List<GetTeamCalendarStatusResponse> result = new ArrayList<>();
+        String impossible = "IMPOSSIBLE";
+        String uncertain = "UNCERTAIN";
+        Long year = Long.parseLong(yearMonth.substring(0, 4));
+        Long month = Long.parseLong(yearMonth.substring(5));
+        int daySize = 31;
+        if (month == 2) {
+            daySize = (year%4==0&&year%100!=0)||year%400==0?29:28;
+        }
+        else if (month%2==0) {
+            daySize = 30;
+        }
+        System.out.println(daySize);
+        for (int day=1; day<=daySize; day++) {
+            String dayString = null;
+            if (day<10) {
+                dayString = "0"+String.valueOf(day);
+            }
+            else {
+                dayString = String.valueOf(day);
+            }
+            LocalDate date = LocalDate.parse(yearMonth + "-" + dayString, DateTimeFormatter.ISO_DATE);
+            List<TeamBanDate> tbdList = teamBanDateRepository.findAllByTeamIdAndDates(teamId, date);
+            String check = "POSSIBLE";
+            for (int i = 0; i < tbdList.size(); i++) {
+                if (tbdList.get(i).getDateStatus().equals(impossible)) {
+                    check = "IMPOSSIBLE";
+                    break;
+                }
+                if (tbdList.get(i).getDateStatus().equals(uncertain)) {
+                    check = "UNCERTAIN";
+                }
+            }
+            result.add(new GetTeamCalendarStatusResponse(date, check));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
"yyyy-mm"형식으로 입력 받은 연도와 월에 해당하는 팀 캘린더의 날짜별 상태를 조회하는 API를 구현하였습니다.