### PR TITLE
Feat: Add promise search API (#249)

### DIFF
--- a/src/main/java/promisor/promisor/domain/bandate/domain/TeamBanDate.java
+++ b/src/main/java/promisor/promisor/domain/bandate/domain/TeamBanDate.java
@@ -10,7 +10,6 @@ import promisor.promisor.domain.team.domain.Team;
 import javax.persistence.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.LAZY;
 

--- a/src/main/java/promisor/promisor/domain/place/domain/Place.java
+++ b/src/main/java/promisor/promisor/domain/place/domain/Place.java
@@ -1,12 +1,11 @@
 package promisor.promisor.domain.place.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import org.springframework.security.core.parameters.P;
-import promisor.promisor.domain.model.BaseEntity;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.persistence.Entity;
 
 /**
  * Place 도메인 객체를 나타내는 자바 빈
@@ -14,6 +13,7 @@ import javax.persistence.Entity;
  * @author Sanha Ko
  */
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Place {
 

--- a/src/main/java/promisor/promisor/domain/promise/api/PromiseController.java
+++ b/src/main/java/promisor/promisor/domain/promise/api/PromiseController.java
@@ -35,10 +35,17 @@ public class PromiseController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/list/{id}")
     public ResponseEntity<List<PromiseResponse>> searchPromiseList(@JwtAuth final String email,
                                                                    @PathVariable("id") final Long teamId) {
-        List<PromiseResponse> response = promiseService.searchPromise(email, teamId);
+        List<PromiseResponse> response = promiseService.searchPromises(email, teamId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PromiseResponse> searchPromise(@JwtAuth final String email,
+                                                         @PathVariable("id") final Long promiseId) {
+        PromiseResponse response = promiseService.searchPromise(email, promiseId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/promisor/promisor/domain/promise/dao/PromiseRepository.java
+++ b/src/main/java/promisor/promisor/domain/promise/dao/PromiseRepository.java
@@ -10,9 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import promisor.promisor.domain.member.domain.Member;
 import promisor.promisor.domain.promise.domain.Promise;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface PromiseRepository extends JpaRepository<Promise, Long> {
 
     @Transactional(readOnly = true)

--- a/src/main/java/promisor/promisor/domain/promise/dto/PromiseResponse.java
+++ b/src/main/java/promisor/promisor/domain/promise/dto/PromiseResponse.java
@@ -1,7 +1,6 @@
 package promisor.promisor.domain.promise.dto;
 
 import lombok.Data;
-import promisor.promisor.domain.promise.domain.Promise;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/promisor/promisor/domain/promise/service/PromiseService.java
+++ b/src/main/java/promisor/promisor/domain/promise/service/PromiseService.java
@@ -87,7 +87,7 @@ public class PromiseService {
      * @return
      * @author Sanha Ko
      */
-    public List<PromiseResponse> searchPromise(String email, Long teamId) {
+    public List<PromiseResponse> searchPromises(String email, Long teamId) {
 
         if (checkMemberInTeam(email, teamId)) {
             throw new MemberNotBelongsToTeam();
@@ -100,6 +100,15 @@ public class PromiseService {
                 .map(p -> new PromiseResponse(p.getId(), p.getPromiseName(),
                         p.getDate(), p.getPromiseLocation()))
                 .collect(toList());
+    }
+
+    public PromiseResponse searchPromise(String email, Long promiseId) {
+        Assert.notNull(email, "엑세스 토큰이 전달되지 않았습니다.");
+        Assert.notNull(promiseId, "약속 Id가 존재하지 않습니다.");
+
+        Promise promise = getPromiseById(promiseId);
+        return new PromiseResponse(promise.getId(), promise.getPromiseName(),
+                promise.getDate(), promise.getPromiseLocation());
     }
 
     private Member getMember(String email) {

--- a/src/main/java/promisor/promisor/global/config/WebConfig.java
+++ b/src/main/java/promisor/promisor/global/config/WebConfig.java
@@ -24,8 +24,9 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedMethods("GET", "POST", "PATCH")
-                .allowedOrigins("http://localhost:8080", "https://promisor.site", "http://promisor.site",
+                .allowedOrigins("http://localhost:8080", "http://promisor.site", "https://promisor.site",
                         "http://localhost:3000", "http://api-storage.cloud.toast.com",
-                        "https://server.promisor.site", "http://server.promisor.site");
+                        "http://server.promisor.site", "https://server.promisor.site",
+                        "http://promisor-client.s3-website.ap-northeast-2.amazonaws.com");
     }
 }


### PR DESCRIPTION
## Description
- 단건 약속 조회 API 구현

## Commits
- 이전 PR에서 리뷰받은 NoArgsConstructor(Protected) 어노테이션을 Place에 추가
- 약속 조회 로직을 구현
- WebConfig에 CORS를 허용할 origin 추가