### PR TITLE
Refactor: 메서드 분리를 통한 가독성 개선

### DIFF
--- a/src/main/java/promisor/promisor/global/auth/AuthorizationExtractor.java
+++ b/src/main/java/promisor/promisor/global/auth/AuthorizationExtractor.java
@@ -1,13 +1,10 @@
 package promisor.promisor.global.auth;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Enumeration;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public class AuthorizationExtractor {
 
@@ -15,23 +12,33 @@ public class AuthorizationExtractor {
     public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
     public static final String BEARER_TYPE = "Bearer";
 
+    private AuthorizationExtractor() {}
+
     public static String extract(HttpServletRequest request) {
 
         Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
         log.info("Header Message: '{}'", headers);
         while (headers.hasMoreElements()) {
             String value = headers.nextElement();
-            if (value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
-                String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
-                request.setAttribute(ACCESS_TOKEN_TYPE,
-                        value.substring(0, BEARER_TYPE.length()).trim());
-                int commaIndex = authHeaderValue.indexOf(',');
-                if (commaIndex > 0) {
-                    authHeaderValue = authHeaderValue.substring(0, commaIndex);
-                }
-                return authHeaderValue;
-            }
+            return checkValueStartsWithBearer(request, value);
         }
         return null;
+    }
+
+    public static String checkValueStartsWithBearer(HttpServletRequest request, String value) {
+        if (value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+            String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
+            request.setAttribute(ACCESS_TOKEN_TYPE, value.substring(0, BEARER_TYPE.length()).trim());
+            int commaIndex = authHeaderValue.indexOf(',');
+            return updateAuthHeaderValue(authHeaderValue, commaIndex);
+        }
+        return null;
+    }
+
+    public static String updateAuthHeaderValue(String authHeaderValue, int commaIndex) {
+        if (commaIndex > 0) {
+            authHeaderValue = authHeaderValue.substring(0, commaIndex);
+        }
+        return authHeaderValue;
     }
 }


### PR DESCRIPTION
## Description
- `AuthorizationExtractor` 파일의  `extract` 로직을 여러 메서드로 분리하여 가독성 개선