### PR TITLE
그룹 조회 쿼리 페이지네이션 적용

### DIFF
--- a/src/main/java/promisor/promisor/domain/calendar/service/CalendarService.java
+++ b/src/main/java/promisor/promisor/domain/calendar/service/CalendarService.java
@@ -48,7 +48,8 @@ public class CalendarService {
         Member member = getMember(email);
         PersonalCalendar personalCalendar = personalCalendarRepository.findPersonalCalendarByMemberAndDate(member, date);
         List<TeamCalendar> teamCalendars = teamCalendarRepository.findAllByMemberAndDate(member, date);
-        List<Team> teams = teamRepository.findAllTeams(member);
+        PageRequest pageRequest = PageRequest.of(0, 10, Sort.Direction.ASC, "teamName");
+        List<Team> teams = teamRepository.findAllTeams(member, pageRequest);
 
         if (personalCalendar != null) {
             personalCalendar.modifyStatus(status);

--- a/src/main/java/promisor/promisor/domain/team/dao/TeamRepository.java
+++ b/src/main/java/promisor/promisor/domain/team/dao/TeamRepository.java
@@ -22,8 +22,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "or m =: member")
     Slice<TeamMember> findTeamInfoWithMembers(@Param("member") Member member, Pageable pageable);
 
-    @Query("select t from Team t join fetch t.teamMembers tm " +
-            "where tm.member in " +
-            "(select m from Member m inner join tm.member mm on mm = :member)")
-    List<Team> findAllTeams(@Param("member") Member member);
+    @Query("select t from Team t " +
+            "where t.id in " +
+            "(select tm.team.id from TeamMember tm where tm.member = :member)")
+    List<Team> findAllTeams(@Param("member") Member member, Pageable pageable);
 }


### PR DESCRIPTION
- 그룹조회 쿼리에 페이지네이션을 적용하였습니다.
- Team과 TeamMember 엔티티가 OneToMany였기 때문에 패치 조인 대신 BatchSize를 적용하였습니다.
   - 1:N 패치 조인시 발생하는 데이터 뻥튀기 현상으로 인한 페이지네이션 오류를 방지하기 위함.